### PR TITLE
Support HTTPS connections

### DIFF
--- a/connection.schema.json
+++ b/connection.schema.json
@@ -59,6 +59,11 @@
               "default": 52773,
               "type": "integer"
             },
+            "https": {
+              "title": "Use HTTPS",
+              "default": false,
+              "type": "boolean"
+            },
             "username": { "$ref": "#/definitions/username" },
             "askForPassword": { "$ref": "#/definitions/askForPassword" }
           },


### PR DESCRIPTION
Fixes #10 

It's literally this easy... all the back-end support was already there, just needed to expose the setting.