### PR TITLE
Support `pathPrefix` for shared webservers (fix #56)

### DIFF
--- a/connection.schema.json
+++ b/connection.schema.json
@@ -48,16 +48,22 @@
               "enum": ["Server and Port"]
             },
             "server": {
-              "title": "Server Address",
+              "title": "Webserver address",
               "type": "string",
               "minLength": 1,
               "default": "localhost"
             },
             "port": {
-              "title": "WebServer Port",
+              "title": "Webserver port",
               "minimum": 1,
               "default": 52773,
               "type": "integer"
+            },
+            "pathPrefix": {
+              "title": "Path prefix (for shared webserver)",
+              "type": "string",
+              "pattern": "^(|\/.*[^\/])$",
+              "default": ""
             },
             "https": {
               "title": "Use HTTPS",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/request-promise": "^4.1.47",
         "request": "^2.88.2",
         "request-promise": "^4.2.6",
-        "uuid": "^7.0.2"
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.14.2",
@@ -5191,9 +5191,10 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "@types/request": "^2.48.5",
     "@types/request-promise": "^4.1.47",
     "request": "^2.88.2",
-    "request-promise": "^4.2.6"
+    "request-promise": "^4.2.6",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.14.2",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
     "@types/request": "^2.48.5",
     "@types/request-promise": "^4.1.47",
     "request": "^2.88.2",
-    "request-promise": "^4.2.6",
-    "uuid": "^7.0.2"
+    "request-promise": "^4.2.6"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.14.2",

--- a/src/ls/irisdb.ts
+++ b/src/ls/irisdb.ts
@@ -56,7 +56,7 @@ export default class IRISdb {
     params?: any,
     headers?: any
   ): Promise<any> {
-    const { https, host, port, username, password } = this.config;
+    const { https, host, port, pathPrefix, username, password } = this.config;
     if (minVersion > this.apiVersion) {
       return Promise.reject(`${path} not supported by API version ${this.apiVersion}`);
     }
@@ -95,7 +95,7 @@ export default class IRISdb {
       maxSockets: 10,
       rejectUnauthorized: https,
     });
-    path = encodeURI(`/api/atelier/${path || ""}${buildParams()}`);
+    path = encodeURI(`${pathPrefix || ""}/api/atelier/${path || ""}${buildParams()}`);
 
     const cookies = this.cookies;
     let auth;


### PR DESCRIPTION
This PR fixes #56 by adding an optional `pathPrefix` property to connection definitions.