### PR TITLE
Respect `http.proxyStrictSSL` setting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,6 +159,7 @@ export async function activate(extContext: ExtensionContext): Promise<IDriverExt
           password: connSpec.password,
           namespace,
           resultSetRowLimit,
+          rejectUnauthorized: vscode.workspace.getConfiguration("http").get("proxyStrictSSL"),
           }
       }
       return connInfo;

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -27,7 +27,7 @@ export default class IRISDriver extends AbstractDriver<IRISdb, DriverOptions> im
     this.showSystem = this.credentials.showSystem || false;
     this.filter = this.credentials.filter || "";
 
-    let { https, server: host, port, pathPrefix, username, password, resultSetRowLimit } = this.credentials;
+    let { https, server: host, port, pathPrefix, username, password, resultSetRowLimit, rejectUnauthorized } = this.credentials;
     config = {
       https,
       host,
@@ -39,7 +39,7 @@ export default class IRISDriver extends AbstractDriver<IRISdb, DriverOptions> im
     };
     this.resultSetRowLimit = resultSetRowLimit;
 
-    const irisdb = new IRISdb(config, resultSetRowLimit);
+    const irisdb = new IRISdb(config, resultSetRowLimit, rejectUnauthorized);
     return irisdb.open()
       .then(() => {
         this.connection = Promise.resolve(irisdb);

--- a/src/ls/irisdb.ts
+++ b/src/ls/irisdb.ts
@@ -27,6 +27,7 @@ export default class IRISdb {
 
   private config: IRISDirect;
   private resultSetRowLimit: number;
+  private rejectUnauthorized: boolean;
   private cookies: string[] = [];
   private _apiVersion = 1;
 
@@ -34,10 +35,11 @@ export default class IRISdb {
     return this._apiVersion;
   }
 
-  public constructor(config: IRISDirect, resultSetRowLimit: number) {
+  public constructor(config: IRISDirect, resultSetRowLimit: number, rejectUnauthorized: boolean = true) {
     this.config = config;
     this.config.namespace = this.config.namespace.toUpperCase();
     this.resultSetRowLimit = resultSetRowLimit;
+    this.rejectUnauthorized = rejectUnauthorized;
   }
 
   public updateCookies(newCookies: string[]): void {
@@ -99,7 +101,7 @@ export default class IRISdb {
     const agent = new (https ? httpsModule : httpModule).Agent({
       keepAlive: true,
       maxSockets: 10,
-      rejectUnauthorized: https,
+      rejectUnauthorized: this.rejectUnauthorized,
     });
     path = encodeURI(`${pathPrefix || ""}/api/atelier/${path || ""}${buildParams()}`);
 


### PR DESCRIPTION
Allows connection to a server that's using a self-signed certificate as long as the user-level setting `"https.proxyStrictSSL": false` is made.

This change makes the driver consistent with other extensions that connect to InterSystems servers.