### PR TITLE
Bump version (overlooked after manual 0.3.0 release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sqltools-intersystems-driver",
   "displayName": "SQLTools InterSystems IRIS",
   "description": "SQLTools Driver for InterSystems IRIS",
-  "version": "0.3.0",
+  "version": "0.3.1-SNAPSHOT",
   "engines": {
     "vscode": "^1.93.0"
   },


### PR DESCRIPTION
When 0.3.0 was released it was apparently done in a way that meant the post-release version bump by our CI didn't occur. This PR corrects that.